### PR TITLE
(#1198) - Allow 0/null as mapreduce keys

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,10 @@ function collationIndex(x) {
   if (Array.isArray(x)) {
     return 4.5;
   }
+  if (typeof x === 'undefined') {
+    // CouchDB indexes both null/undefined as null
+    return 1;
+  }
 }
 module.exports = pouchCollate;
 function pouchCollate(a, b) {
@@ -58,7 +62,7 @@ function pouchCollate(a, b) {
   if ((ai - bi) !== 0) {
     return ai - bi;
   }
-  if (a === null) {
+  if (a === null || typeof a === 'undefined') {
     return 0;
   }
   if (typeof a === 'number') {


### PR DESCRIPTION
CouchDB allows 0 and null as separate keys in
mapreduce queries. This commit makes PouchDB behave like CouchDB.
Since this is a multi-repo change that affects pouchdb,
pouchdb-collate, and pouchdb-mapreduce, I wasn't really sure
how to structure this commit, so I'm just including the same
commit message in 3 separate commits.
