### PR TITLE
(#5) - Ensure bool identity comparison returns 0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ function pouchCollate(a, b) {
     return a - b;
   }
   if (typeof a === 'boolean') {
-    return a < b ? -1 : 1;
+    return a === b ? 0 : (a < b ? -1 : 1);
   }
   if (typeof a === 'string') {
     return stringCollate(a, b);

--- a/test/test.js
+++ b/test/test.js
@@ -36,8 +36,8 @@ describe('collate',function(){
 		collate(c.array,c.array).should.equal(0);
 	});
 	it('compare boolean to itself', function(){
-		collate(a.bool,a.bool).should.equal(1);
-		collate(b.bool,b.bool).should.equal(1);
+		collate(a.bool,a.bool).should.equal(0);
+		collate(b.bool,b.bool).should.equal(0);
 	});
 	it('compare string to itself', function(){
 		collate(a.string,a.string).should.equal(0);


### PR DESCRIPTION
Fix to ensure that collate(true, true) and collate(false, false)
both return 0.
