### PR TITLE
(pouchdb/mapreduce#15) - handle NaN/Inf/dates

### DIFF
--- a/dist/pouchdb-collate.js
+++ b/dist/pouchdb-collate.js
@@ -1,10 +1,53 @@
 !function(e){"object"==typeof exports?module.exports=e():"function"==typeof define&&define.amd?define(e):"undefined"!=typeof window?window.pouchCollate=e():"undefined"!=typeof global?global.pouchCollate=e():"undefined"!=typeof self&&(self.pouchCollate=e())}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
+exports.collate = function (a, b) {
+  a = exports.normalizeKey(a);
+  b = exports.normalizeKey(b);
+  var ai = collationIndex(a);
+  var bi = collationIndex(b);
+  if ((ai - bi) !== 0) {
+    return ai - bi;
+  }
+  if (a === null) {
+    return 0;
+  }
+  if (typeof a === 'number') {
+    return a - b;
+  }
+  if (typeof a === 'boolean') {
+    return a === b ? 0 : (a < b ? -1 : 1);
+  }
+  if (typeof a === 'string') {
+    return stringCollate(a, b);
+  }
+  if (Array.isArray(a)) {
+    return arrayCollate(a, b);
+  }
+  if (typeof a === 'object') {
+    return objectCollate(a, b);
+  }
+}
+
+// couch considers null/NaN/Infinity/-Infinity === undefined,
+// for the purposes of mapreduce indexes. also, dates get stringified.
+exports.normalizeKey = function (key) {
+  if (typeof key === 'undefined') {
+    return null;
+  } else if (typeof key === 'number') {
+    if (key === Infinity || key === -Infinity || isNaN(key)) {
+      return null;
+    }
+  } else if (key instanceof Date) {
+    return key.toJSON();
+  }
+  return key;
+}
+
 function arrayCollate(a, b) {
   var len = Math.min(a.length, b.length);
   for (var i = 0; i < len; i++) {
-    var sort = pouchCollate(a[i], b[i]);
+    var sort = exports.collate(a[i], b[i]);
     if (sort !== 0) {
       return sort;
     }
@@ -23,12 +66,12 @@ function objectCollate(a, b) {
   var len = Math.min(ak.length, bk.length);
   for (var i = 0; i < len; i++) {
     // First sort the keys
-    var sort = pouchCollate(ak[i], bk[i]);
+    var sort = exports.collate(ak[i], bk[i]);
     if (sort !== 0) {
       return sort;
     }
     // if the keys are equal sort the values
-    sort = pouchCollate(a[ak[i]], b[bk[i]]);
+    sort = exports.collate(a[ak[i]], b[bk[i]]);
     if (sort !== 0) {
       return sort;
     }
@@ -40,6 +83,7 @@ function objectCollate(a, b) {
 // The collation is defined by erlangs ordered terms
 // the atoms null, true, false come first, then numbers, strings,
 // arrays, then objects
+// null/undefined/NaN/Infinity/-Infinity are all considered null
 function collationIndex(x) {
   var id = ['boolean', 'number', 'string', 'object'];
   if (id.indexOf(typeof x) !== -1) {
@@ -51,37 +95,8 @@ function collationIndex(x) {
   if (Array.isArray(x)) {
     return 4.5;
   }
-  if (typeof x === 'undefined') {
-    // CouchDB indexes both null/undefined as null
-    return 1;
-  }
 }
-module.exports = pouchCollate;
-function pouchCollate(a, b) {
-  var ai = collationIndex(a);
-  var bi = collationIndex(b);
-  if ((ai - bi) !== 0) {
-    return ai - bi;
-  }
-  if (a === null || typeof a === 'undefined') {
-    return 0;
-  }
-  if (typeof a === 'number') {
-    return a - b;
-  }
-  if (typeof a === 'boolean') {
-    return a === b ? 0 : (a < b ? -1 : 1);
-  }
-  if (typeof a === 'string') {
-    return stringCollate(a, b);
-  }
-  if (Array.isArray(a)) {
-    return arrayCollate(a, b);
-  }
-  if (typeof a === 'object') {
-    return objectCollate(a, b);
-  }
-};;
+
 },{}]},{},[1])
 (1)
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,52 @@
 'use strict';
 
+exports.collate = function (a, b) {
+  a = exports.normalizeKey(a);
+  b = exports.normalizeKey(b);
+  var ai = collationIndex(a);
+  var bi = collationIndex(b);
+  if ((ai - bi) !== 0) {
+    return ai - bi;
+  }
+  if (a === null) {
+    return 0;
+  }
+  if (typeof a === 'number') {
+    return a - b;
+  }
+  if (typeof a === 'boolean') {
+    return a === b ? 0 : (a < b ? -1 : 1);
+  }
+  if (typeof a === 'string') {
+    return stringCollate(a, b);
+  }
+  if (Array.isArray(a)) {
+    return arrayCollate(a, b);
+  }
+  if (typeof a === 'object') {
+    return objectCollate(a, b);
+  }
+}
+
+// couch considers null/NaN/Infinity/-Infinity === undefined,
+// for the purposes of mapreduce indexes. also, dates get stringified.
+exports.normalizeKey = function (key) {
+  if (typeof key === 'undefined') {
+    return null;
+  } else if (typeof key === 'number') {
+    if (key === Infinity || key === -Infinity || isNaN(key)) {
+      return null;
+    }
+  } else if (key instanceof Date) {
+    return key.toJSON();
+  }
+  return key;
+}
+
 function arrayCollate(a, b) {
   var len = Math.min(a.length, b.length);
   for (var i = 0; i < len; i++) {
-    var sort = pouchCollate(a[i], b[i]);
+    var sort = exports.collate(a[i], b[i]);
     if (sort !== 0) {
       return sort;
     }
@@ -22,12 +65,12 @@ function objectCollate(a, b) {
   var len = Math.min(ak.length, bk.length);
   for (var i = 0; i < len; i++) {
     // First sort the keys
-    var sort = pouchCollate(ak[i], bk[i]);
+    var sort = exports.collate(ak[i], bk[i]);
     if (sort !== 0) {
       return sort;
     }
     // if the keys are equal sort the values
-    sort = pouchCollate(a[ak[i]], b[bk[i]]);
+    sort = exports.collate(a[ak[i]], b[bk[i]]);
     if (sort !== 0) {
       return sort;
     }
@@ -39,6 +82,7 @@ function objectCollate(a, b) {
 // The collation is defined by erlangs ordered terms
 // the atoms null, true, false come first, then numbers, strings,
 // arrays, then objects
+// null/undefined/NaN/Infinity/-Infinity are all considered null
 function collationIndex(x) {
   var id = ['boolean', 'number', 'string', 'object'];
   if (id.indexOf(typeof x) !== -1) {
@@ -50,34 +94,4 @@ function collationIndex(x) {
   if (Array.isArray(x)) {
     return 4.5;
   }
-  if (typeof x === 'undefined') {
-    // CouchDB indexes both null/undefined as null
-    return 1;
-  }
 }
-module.exports = pouchCollate;
-function pouchCollate(a, b) {
-  var ai = collationIndex(a);
-  var bi = collationIndex(b);
-  if ((ai - bi) !== 0) {
-    return ai - bi;
-  }
-  if (a === null || typeof a === 'undefined') {
-    return 0;
-  }
-  if (typeof a === 'number') {
-    return a - b;
-  }
-  if (typeof a === 'boolean') {
-    return a === b ? 0 : (a < b ? -1 : 1);
-  }
-  if (typeof a === 'string') {
-    return stringCollate(a, b);
-  }
-  if (Array.isArray(a)) {
-    return arrayCollate(a, b);
-  }
-  if (typeof a === 'object') {
-    return objectCollate(a, b);
-  }
-};;

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,9 @@
+'use strict';
+
 var should = require('chai').should();
-var collate = require('../lib');
+var pouchCollate = require('../lib');
+var collate = pouchCollate.collate;
+var normalizeKey = pouchCollate.normalizeKey;
 
 describe('collate',function(){
 	var a = {
@@ -96,4 +100,35 @@ describe('collate',function(){
 		collate(function(){},a.number).should.not.equal(collate(function(){},a.number));
 		collate(function(){},b.number).should.not.equal(collate(function(){},b.number));
 	});
+});
+
+describe('normalizeKey',function(){
+
+  it('verify key normalizations', function(){
+    var normalizations = [
+      [null, null],
+      [NaN, null],
+      [undefined, null],
+      [Infinity, null],
+      [-Infinity, null],
+      ['', ''],
+      ['foo', 'foo'],
+      ['0', '0'],
+      ['1', '1'],
+      [0, 0],
+      [1, 1],
+      [Number.MAX_VALUE, Number.MAX_VALUE],
+      [new Date('1982-11-30T00:00:00.000Z'), '1982-11-30T00:00:00.000Z'] // date Thriller was released
+    ];
+
+    normalizations.forEach(function(normalization){
+      var original = normalization[0];
+      var expected = normalization[1];
+      var normalized = normalizeKey(original);
+
+      var message = 'check normalization of ' + JSON.stringify(original) + ' to ' + JSON.stringify(expected) +
+        ', got ' + JSON.stringify(normalized);;
+      should.equal(normalized, expected, message);
+    });
+  });
 });


### PR DESCRIPTION
Ensures that PouchDB mimics CouchDB's
behavior for mapreduce keys containing
NaN, Infinity, -Infinity, and dates.

I ended up pulling the normalize function out of mapreduce and into collate.  I didn't see a convention for how we
want to export a dependency with multiple functions; hope what I chose is okay!

This PR is paired with pouchdb/mapreduce#23.
