### PR TITLE
(daleharvey/pouchdb#1658) - add indexable string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,11 @@
 'use strict';
 
+var MIN_MAGNITUDE = -324; // verified by -Number.MIN_VALUE
+var MAGNITUDE_DIGITS = 3; // ditto
+var SEP = '_'; // TODO: in production it should be empty
+
+var utils = require('./utils');
+
 exports.collate = function (a, b) {
   a = exports.normalizeKey(a);
   b = exports.normalizeKey(b);
@@ -39,6 +45,50 @@ exports.normalizeKey = function (key) {
     return key.toJSON();
   }
   return key;
+};
+
+// convert the given key to a string that would be appropriate
+// for lexical sorting, e.g. within a database, where the
+// sorting is the same given by the collate() function.
+exports.toIndexableString = function (key) {
+  var zero = '\u0000';
+
+  key = exports.normalizeKey(key);
+
+  var result = collationIndex(key) + SEP;
+
+  if (key !== null) {
+    if (typeof key === 'boolean') {
+      result += (key ? 1 : 0);
+    } else if (typeof key === 'number') {
+      result += numToIndexableString(key) + zero;
+    } else if (typeof key === 'string') {
+      // We've to be sure that key does not contain \u0000
+      // Do order-preserving replacements:
+      // 0 -> 1, 1
+      // 1 -> 1, 2
+      // 2 -> 2, 2
+      key = key.replace(/\u0002/g, '\u0002\u0002');
+      key = key.replace(/\u0001/g, '\u0001\u0002');
+      key = key.replace(/\u0000/g, '\u0001\u0001');
+
+      result += key + zero;
+    } else if (Array.isArray(key)) {
+      key.forEach(function (element) {
+        result += exports.toIndexableString(element);
+      });
+      result += zero;
+    } else if (typeof key === 'object') {
+      var arr = [];
+      var keys = Object.keys(key);
+      keys.forEach(function (objKey) {
+        arr.push([objKey, key[objKey]]);
+      });
+      result += exports.toIndexableString(arr);
+    }
+  }
+
+  return result;
 };
 
 function arrayCollate(a, b) {
@@ -82,12 +132,62 @@ function objectCollate(a, b) {
 // arrays, then objects
 // null/undefined/NaN/Infinity/-Infinity are all considered null
 function collationIndex(x) {
-  if (x === null) {
-    return 1;
-  }
-  var type = ['boolean', 'number', 'string', 'object'].indexOf(typeof x);
+  var id = ['boolean', 'number', 'string', 'object'];
+  var idx = id.indexOf(typeof x);
   //false if -1 otherwise true, but fast!!!!1
-  if (~type) {
-    return Array.isArray(x) ? 4.5 : (type + 2);
+  if (~idx) {
+    if (x === null) {
+      return 1;
+    }
+    if (Array.isArray(x)) {
+      return 5;
+    }
+    return idx < 3 ? (idx + 2) : (idx + 3);
   }
+  if (Array.isArray(x)) {
+    return 5;
+  }
+}
+
+// conversion:
+// x yyy zz...zz
+// x = 0 for negative, 1 for 0, 2 for positive
+// y = exponent (for negative numbers negated) moved so that it's >= 0
+// z = mantisse
+function numToIndexableString(num) {
+
+  // convert number to exponential format for easier and
+  // more succinct string sorting
+  var expFormat = num.toExponential().split(/e\+?/);
+  var magnitude = parseInt(expFormat[1], 10);
+
+  var neg = num < 0;
+
+  if (num === 0) {
+    return '1';
+  }
+
+  var result = neg ? '0' : '2';
+
+  // first sort by magnitude
+  // it's easier if all magnitudes are positive
+  var magForComparison = ((neg ? -magnitude : magnitude) - MIN_MAGNITUDE);
+  var magString = utils.padLeft((magForComparison).toString(), '0', MAGNITUDE_DIGITS);
+
+  result += SEP + magString;
+
+  // then sort by the factor
+  var factor = Math.abs(parseFloat(expFormat[0])); // [1..10)
+  if (neg) { // for negative reverse ordering
+    factor = 10 - factor;
+  }
+
+  var factorStr = factor.toFixed(20);
+
+  // strip zeros from the end
+  factorStr = factorStr.replace(/\.?0+$/, '');
+
+  result += SEP + factorStr;
+
+  return result;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,70 @@
+'use strict';
+
+function pad(str, padWith, upToLength) {
+  var padding = '';
+  var targetLength = upToLength - str.length;
+  while (padding.length < targetLength) {
+    padding += padWith;
+  }
+  return padding;
+}
+
+exports.padLeft = function (str, padWith, upToLength) {
+  var padding = pad(str, padWith, upToLength);
+  return padding + str;
+};
+
+exports.padRight = function (str, padWith, upToLength) {
+  var padding = pad(str, padWith, upToLength);
+  return str + padding;
+};
+
+exports.stringLexCompare = function (a, b) {
+
+  var aLen = a.length;
+  var bLen = b.length;
+
+  var i;
+  for (i = 0; i < aLen; i++) {
+    if (i === bLen) {
+      // b is shorter substring of a
+      return 1;
+    }
+    var aChar = a.charAt(i);
+    var bChar = b.charAt(i);
+    if (aChar !== bChar) {
+      return aChar < bChar ? -1 : 1;
+    }
+  }
+
+  if (aLen < bLen) {
+    // a is shorter substring of b
+    return -1;
+  }
+
+  return 0;
+};
+
+/*
+ * returns the decimal form for the given integer, i.e. writes
+ * out all the digits (in base-10) instead of using scientific notation
+ */
+exports.intToDecimalForm = function (int) {
+
+  var isNeg = int < 0;
+  var result = '';
+
+  do {
+    var remainder = isNeg ? -Math.ceil(int % 10) : Math.floor(int % 10);
+
+    result = remainder + result;
+    int = isNeg ? Math.ceil(int / 10) : Math.floor(int / 10);
+  } while (int);
+
+
+  if (isNeg && result !== '0') {
+    result = '-' + result;
+  }
+
+  return result;
+};


### PR DESCRIPTION
Following daleharvey/pouchdb#1658 and
pouchdb/mapreduce#12, this adds the
toIndexableString method, which allows us
to emulate CouchDB's standard collation
to a reasonable degree of fidelity (e.g. no
ICU ordering for strings).
