### PR TITLE
(#12) - remove unnecessary separator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 var MIN_MAGNITUDE = -324; // verified by -Number.MIN_VALUE
 var MAGNITUDE_DIGITS = 3; // ditto
-var SEP = '_'; // TODO: in production it should be empty
+var SEP = ''; // set to '_' for easier debugging 
 
 var utils = require('./utils');
 


### PR DESCRIPTION
The underscore was only used for debugging
and should be removed before we publish
the next version of PouchDB.
