### PR TITLE
(#13) - use switch statements, fix zero usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,78 +17,79 @@ exports.collate = function (a, b) {
   if (a === null) {
     return 0;
   }
-  if (typeof a === 'number') {
-    return a - b;
+  switch (typeof a) {
+    case 'number':
+      return a - b;
+    case 'boolean':
+      return a === b ? 0 : (a < b ? -1 : 1);
+    case 'string':
+      return stringCollate(a, b);
   }
-  if (typeof a === 'boolean') {
-    return a === b ? 0 : (a < b ? -1 : 1);
-  }
-  if (typeof a === 'string') {
-    return stringCollate(a, b);
-  }
-  if (Array.isArray(a)) {
-    return arrayCollate(a, b);
-  }
-  return objectCollate(a, b);
+  return Array.isArray(a) ? arrayCollate(a, b) : objectCollate(a, b);
 };
 
 // couch considers null/NaN/Infinity/-Infinity === undefined,
 // for the purposes of mapreduce indexes. also, dates get stringified.
 exports.normalizeKey = function (key) {
-  if (typeof key === 'undefined') {
-    return null;
-  } else if (typeof key === 'number') {
-    if (key === Infinity || key === -Infinity || isNaN(key)) {
+  switch (typeof key) {
+    case 'undefined':
       return null;
-    }
-  } else if (key instanceof Date) {
-    return key.toJSON();
+    case 'number':
+      if (key === Infinity || key === -Infinity || isNaN(key)) {
+        return null;
+      }
+      return key;
   }
-  return key;
+  return key instanceof Date ? key.toJSON() : key;
 };
+
+function indexify(key) {
+  if (key !== null) {
+    switch (typeof key) {
+      case 'boolean':
+        return key ? 1 : 0;
+      case 'number':
+        return numToIndexableString(key);
+      case 'string':
+        // We've to be sure that key does not contain \u0000
+        // Do order-preserving replacements:
+        // 0 -> 1, 1
+        // 1 -> 1, 2
+        // 2 -> 2, 2
+        return key
+          .replace(/\u0002/g, '\u0002\u0002')
+          .replace(/\u0001/g, '\u0001\u0002')
+          .replace(/\u0000/g, '\u0001\u0001');
+      case 'object':
+        var isArray = Array.isArray(key);
+        var arr = isArray ? key : Object.keys(key);
+        var i = -1;
+        var len = arr.length;
+        var result = '';
+        if (isArray) {
+          while (++i < len) {
+            result += exports.toIndexableString(arr[i]);
+          }
+        } else {
+          while (++i < len) {
+            var objKey = arr[i];
+            result += exports.toIndexableString(objKey) +
+                exports.toIndexableString(key[objKey]);
+          }
+        }
+        return result;
+    }
+  }
+  return '';
+}
 
 // convert the given key to a string that would be appropriate
 // for lexical sorting, e.g. within a database, where the
 // sorting is the same given by the collate() function.
 exports.toIndexableString = function (key) {
   var zero = '\u0000';
-
   key = exports.normalizeKey(key);
-
-  var result = collationIndex(key) + SEP;
-
-  if (key !== null) {
-    if (typeof key === 'boolean') {
-      result += (key ? 1 : 0);
-    } else if (typeof key === 'number') {
-      result += numToIndexableString(key) + zero;
-    } else if (typeof key === 'string') {
-      // We've to be sure that key does not contain \u0000
-      // Do order-preserving replacements:
-      // 0 -> 1, 1
-      // 1 -> 1, 2
-      // 2 -> 2, 2
-      key = key.replace(/\u0002/g, '\u0002\u0002');
-      key = key.replace(/\u0001/g, '\u0001\u0002');
-      key = key.replace(/\u0000/g, '\u0001\u0001');
-
-      result += key + zero;
-    } else if (Array.isArray(key)) {
-      key.forEach(function (element) {
-        result += exports.toIndexableString(element);
-      });
-      result += zero;
-    } else if (typeof key === 'object') {
-      var arr = [];
-      var keys = Object.keys(key);
-      keys.forEach(function (objKey) {
-        arr.push([objKey, key[objKey]]);
-      });
-      result += exports.toIndexableString(arr);
-    }
-  }
-
-  return result;
+  return collationIndex(key) + SEP + indexify(key) + zero;
 };
 
 function arrayCollate(a, b) {


### PR DESCRIPTION
Some small fixes here:
- use `switch` instead of `if`.  It's faster on Safari, and uses less code.
- for `toIndexableString()` on objects and arrays, prefer regular for-loops instead of `Array.forEach`.
- we weren't consistent in adding the `zero` at the end.  Couldn't find a test case that would fail before, but in any case our usage is consistent now.

All the tests pass, and the mapreduce tests pass as well.
