### PR TITLE
a prototype with gulpjs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,9 @@
 var gulp = require('gulp'),
   jshint = require('gulp-jshint'),
   mocha = require('gulp-mocha'),
-  istanbul = require('gulp-istanbul');
+  istanbul = require('gulp-istanbul'),
+  browserify = require('gulp-browserify'),
+  rename = require('gulp-rename');
 
 gulp.task('hint', function () {
   return gulp.src(['lib/*.js', 'test/*.js', 'gulpfile.js'])
@@ -14,7 +16,7 @@ gulp.task('hint', function () {
 });
 
 gulp.task('test', function (cb) {
-  return gulp.src(['lib/*.js'])
+  gulp.src('lib/*.js')
     .pipe(istanbul())
     .on('end', function () {
       gulp.src('test/*.js')
@@ -24,4 +26,11 @@ gulp.task('test', function (cb) {
     });
 });
 
+gulp.task('browserify', function () {
+  return gulp.src('lib/index.js')
+    .pipe(browserify())
+    .pipe(rename('pouchdb-collate.js'))
+    .pipe(gulp.dest('./dist'));
+});
 
+gulp.task('build', ['hint', 'test', 'browserify']);

--- a/package.json
+++ b/package.json
@@ -14,19 +14,20 @@
     "couchdb"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/jshint -c .jshintrc lib/*.js test/*.js && ./node_modules/istanbul/lib/cli.js test ./node_modules/mocha/bin/_mocha test/test.js",
-    "build": "mkdir -p dist && browserify lib/index.js -s pouchCollate -o dist/pouchdb-collate.js"
+    "test": "./node_modules/gulp/bin/gulp.js test",
+    "build": "./node_modules/gulp/bin/gulp.js build"
   },
   "license": "Apache",
   "bugs": {
     "url": "https://github.com/pouchdb/collate/issues"
   },
   "devDependencies": {
-    "browserify": "~2.36.1",
     "chai": "~1.8.1",
     "gulp": "^3.6.2",
+    "gulp-browserify": "^0.5.0",
     "gulp-istanbul": "^0.1.1",
     "gulp-jshint": "^1.5.5",
-    "gulp-mocha": "^0.4.1"
+    "gulp-mocha": "^0.4.1",
+    "gulp-rename": "^1.2.0"
   }
 }


### PR DESCRIPTION
Make use of gulpjs for building. Available tasks:
- `hint`: for hinting all our js
- `test`: for testing coverage with `istanbul` and testing with `mocha`
- `build`: combine the above and also run `browserify` to create pouchdb-collate.js in `dist/` folder

Regarding backwards compatibility, `npm test` and `npm build` are calling the corresponding gulp tasks.
